### PR TITLE
migration for materialized view

### DIFF
--- a/migrations/20170323021820-create-compounds-view.js
+++ b/migrations/20170323021820-create-compounds-view.js
@@ -1,0 +1,53 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    const extract = {
+      iupac_name_allowed: { label: 'IUPAC Name', name: 'Allowed' },
+      iupac_name_cas: { label: 'IUPAC Name', name: 'CAS-like Style' },
+      iupac_name_preferred: { label: 'IUPAC Name', name: 'Preferred' },
+      iupac_name_systematic: { label: 'IUPAC Name', name: 'Systematic' },
+      iupac_name_traditional: { label: 'IUPAC Name', name: 'Traditional' },
+      inchi_standard: { label: 'InChI', name: 'Standard' },
+      inchi_key_standard: { label: 'InChIKey', name: 'Standard' },
+      smiles_isomeric: { label: 'SMILES', name: 'Isomeric' },
+      smiles_canonical: { label: 'SMILES', name: 'Canonical' },
+    };
+
+    const columns = Object.entries(extract).map(([key, data]) => `
+      (
+        SELECT
+        props.prop->'value'->>'sval'
+        FROM (
+          SELECT json_array_elements(compounds.data->'props') prop
+        ) props
+        WHERE props.prop->'urn'->>'label' = '${data.label}'
+        AND props.prop->'urn'->>'name' = '${data.name}'
+      ) AS ${key}
+    `);
+
+    const migration = `
+      CREATE MATERIALIZED VIEW compounds_view AS
+      SELECT
+      id,
+      cid,
+      ${columns.join(',')},
+      data
+      FROM compounds
+    `;
+
+    const indices = Object.keys(extract).map((key) => (
+      () => queryInterface.addIndex('compounds_view', [key], {
+        indexName: `${key}_index`
+      })
+    ));
+
+    return queryInterface.sequelize.query(migration).then(() =>
+      Promise.all(indices)
+    );
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.sequelize.query('DROP MATERIALIZED VIEW compounds_view');
+  }
+};


### PR DESCRIPTION
fixes #10 

```
shchem=# \d+ compounds_view
                      Materialized view "public.compounds_view"
         Column         |  Type   | Modifiers | Storage  | Stats target | Description
------------------------+---------+-----------+----------+--------------+-------------
 id                     | integer |           | plain    |              |
 cid                    | integer |           | plain    |              |
 iupac_name_allowed     | text    |           | extended |              |
 iupac_name_cas         | text    |           | extended |              |
 iupac_name_preferred   | text    |           | extended |              |
 iupac_name_systematic  | text    |           | extended |              |
 iupac_name_traditional | text    |           | extended |              |
 inchi_standard         | text    |           | extended |              |
 inchi_key_standard     | text    |           | extended |              |
 smiles_isomeric        | text    |           | extended |              |
 smiles_canonical       | text    |           | extended |              |
 data                   | json    |           | extended |              |
View definition:
 SELECT compounds.id,
    compounds.cid,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'IUPAC Name'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Allowed'::text) AS iupac_name_allowed,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'IUPAC Name'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'CAS-like Style'::text) AS iupac_name_cas,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'IUPAC Name'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Preferred'::text) AS iupac_name_preferred,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'IUPAC Name'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Systematic'::text) AS iupac_name_systematic,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'IUPAC Name'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Traditional'::text) AS iupac_name_traditional,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'InChI'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Standard'::text) AS inchi_standard,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'InChIKey'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Standard'::text) AS inchi_key_standard,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'SMILES'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Isomeric'::text) AS smiles_isomeric,
    ( SELECT (props.prop -> 'value'::text) ->> 'sval'::text
           FROM ( SELECT json_array_elements(compounds.data -> 'props'::text) AS prop) props
          WHERE ((props.prop -> 'urn'::text) ->> 'label'::text) = 'SMILES'::text AND ((props.prop -> 'urn'::text) ->> 'name'::text) = 'Canonical'::text) AS smiles_canonical,
    compounds.data
   FROM compounds;
```