### PR TITLE
query route

### DIFF
--- a/server/controllers/api/v1/compounds.js
+++ b/server/controllers/api/v1/compounds.js
@@ -1,22 +1,21 @@
 const { CompoundView, SEARCHABLE } = require('../../../models/compoundView');
 var rdkit = require('../../../util/rdkit');
 
+var compoundToJson = (compound) => ({
+  cid: compound.cid,
+  img: "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/" + compound.cid + "/PNG",
+  props: compound.data.props.map((prop) => ({
+    label: prop.urn.label,
+    name: prop.urn.name,
+    value: prop.value.sval,
+    img: prop.urn.label == 'SMILES' && rdkit.fromSmiles(prop.value.sval),
+  }))
+});
+
 module.exports.show = function(req, res) {
   CompoundView.findOne({
     cid: req.params.cid
-  }).then(compound => {
-    data = {
-      cid: compound.cid,
-      img: "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/" + compound.cid + "/PNG",
-      props: compound.data.props.map((prop) => ({
-        label: prop.urn.label,
-        name: prop.urn.name,
-        value: prop.value.sval,
-        img: prop.urn.label == 'SMILES' && rdkit.fromSmiles(prop.value.sval),
-      }))
-    };
-    res.json(data);
-  });
+  }).then(compound => res.json(compoundToJson(compound)));
 };
 
 module.exports.query = function(req, res) {
@@ -28,6 +27,6 @@ module.exports.query = function(req, res) {
   CompoundView.findAll({
     where: { $or: conditions }
   }).then((compounds) => {
-    res.json(compounds.map((compound) => compound.cid));
+    res.json(compounds.map((compound) => compoundToJson(compound)));
   });
 };

--- a/server/controllers/api/v1/compounds.js
+++ b/server/controllers/api/v1/compounds.js
@@ -1,8 +1,8 @@
-const Compound = require('../../../models/compound');
+const { CompoundView, SEARCHABLE } = require('../../../models/compoundView');
 var rdkit = require('../../../util/rdkit');
 
-module.exports.show = function(req, res){
-  Compound.findOne({
+module.exports.show = function(req, res) {
+  CompoundView.findOne({
     cid: req.params.cid
   }).then(compound => {
     data = {
@@ -16,5 +16,18 @@ module.exports.show = function(req, res){
       }))
     };
     res.json(data);
+  });
+};
+
+module.exports.query = function(req, res) {
+  conditions = SEARCHABLE.map((searchable) => {
+    const condition = {};
+    condition[searchable] = req.query.query;
+    return condition;
+  });
+  CompoundView.findAll({
+    where: { $or: conditions }
+  }).then((compounds) => {
+    res.json(compounds.map((compound) => compound.cid));
   });
 };

--- a/server/models/compoundView.js
+++ b/server/models/compoundView.js
@@ -1,0 +1,30 @@
+const Sequelize = require('sequelize');
+const sq = require('../sq');
+
+const SEARCHABLE = [
+  'iupac_name_allowed',
+  'iupac_name_cas',
+  'iupac_name_preferred',
+  'iupac_name_systematic',
+  'iupac_name_traditional',
+  'inchi_standard',
+  'inchi_key_standard',
+  'smiles_isomeric',
+  'smiles_canonical',
+]
+
+const columns = {
+  cid: Sequelize.INTEGER,
+  data: Sequelize.JSON,
+};
+SEARCHABLE.forEach((column) => {
+  columns[column] = Sequelize.TEXT;
+});
+
+const CompoundView = sq.define('compound_view', columns, {
+  createdAt: false,
+  timestamps: false,
+  tableName: 'compounds_view'
+});
+
+module.exports = { CompoundView, SEARCHABLE };

--- a/server/routes/api/v1.js
+++ b/server/routes/api/v1.js
@@ -3,6 +3,7 @@ var router = express.Router();
 var compounds = require('../../controllers/api/v1/compounds');
 
 /* GET compound */
+router.get('/compounds/query', compounds.query);
 router.get('/compounds/:cid', compounds.show);
 
 module.exports = router;


### PR DESCRIPTION
fixes #11 

# Summary
`/compounds/query?query=foo` searches all searchable fields for `foo` and returns list of `cid`s

<img width="943" alt="screen shot 2017-03-22 at 11 42 21 pm" src="https://cloud.githubusercontent.com/assets/241819/24232493/5b58231e-0f59-11e7-9bb7-528d16239c37.png">
